### PR TITLE
Fix insights icon

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -329,7 +329,7 @@
                         and comprehensive reporting for data-driven decision making.
                     </p>
                     <a href="/insights/" class="card-button success">
-                        <i class="fas fa-analytics"></i>
+                        <i class="fas fa-chart-line"></i>
                         View Insights
                     </a>
                 </div>


### PR DESCRIPTION
## Summary
- fix fontawesome icon for the Insights link on the dashboard

## Testing
- `None`

------
https://chatgpt.com/codex/tasks/task_e_688d05be6ad4832884f53399cdf8e66d