### PR TITLE
Add tests for utility modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,3 +6,6 @@ requires-python = ">=3.12"
 dependencies = [
     "flask>=3.1.1",
 ]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/tests/test_offers.py
+++ b/tests/test_offers.py
@@ -1,0 +1,22 @@
+import pytest
+
+from app.utils.offers import generate_loan_offers
+
+
+def test_no_offers_below_threshold():
+    assert generate_loan_offers(49.9) == []
+
+
+def test_offers_at_exact_threshold():
+    expected = [35000, 25000, 15000, 10000, 7500, 5000]
+    assert generate_loan_offers(50) == expected
+
+
+def test_offers_between_50_and_60():
+    expected = [35000, 25000, 15000, 10000, 7500, 5000]
+    assert generate_loan_offers(55) == expected
+
+
+def test_next_tier_at_60():
+    expected = [50000, 35000, 25000, 15000, 10000, 5000]
+    assert generate_loan_offers(60) == expected

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -1,0 +1,14 @@
+from app.utils.scoring import calculate_score
+
+
+def test_calculate_score_minimal_ruleset():
+    rules = {
+        "section": {
+            "num": {"weight": 10},
+            "bool": {"weight": 5},
+        }
+    }
+    input_data = {"num": 7, "bool": "yes"}
+    result = calculate_score(input_data, rules)
+    assert result == {"total_score": 80.0, "raw_score": 12.0, "max_possible": 15}
+


### PR DESCRIPTION
## Summary
- configure pytest and set test paths
- add tests for generate_loan_offers around the 50 point threshold
- add a simple scoring test with a minimal ruleset
- ignore `__pycache__`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d05b52c9c8328810380a557e86389