### PR TITLE
Include input in finance response

### DIFF
--- a/app/routes/scorecard.py
+++ b/app/routes/scorecard.py
@@ -56,4 +56,4 @@ def calculate():
     with open(log_path, 'a') as f:
         f.write(json.dumps(log) + '\n')
 
-    return jsonify({"score": result, "offers": offers})
+    return jsonify({"score": result, "offers": offers, "input": data})


### PR DESCRIPTION
## Summary
- return user input from the finance route so the client can render it

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688d05b326d08328a804246b04bb4bdc