### PR TITLE
Fix second owner logic and tier labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ o Auto-calculates “Years in Business” from business start date
 • Each field has a point weight defined in finance.json
 • Total score normalized to a maximum of 100
 • Risk Tier displayed based on score:
-o Low Risk
-o Moderate Risk
-o High Risk
-o Super High Risk (auto-deny, no offers)
+  - **Low Risk** (80+)
+  - **Moderate Risk** (60–79)
+  - **High Risk** (50–59)
+  - **Super High Risk** (<50, auto‑deny)
 3. Loan Offer Generation
 • Generates up to 6 dynamic offers
 • Minimum offer: $5,000

--- a/app/utils/scoring.py
+++ b/app/utils/scoring.py
@@ -14,7 +14,10 @@ def calculate_score(input_data, rules):
     score = 0
     max_score = 0
     owner1_pct = float(input_data.get("owner1_ownership_pct", 100))
-    include_owner2 = owner1_pct < 59
+    owner2_provided = any(
+        str(v).strip() for k, v in input_data.items() if k.startswith("owner2_")
+    )
+    include_owner2 = owner1_pct < 59 and owner2_provided
 
     for section, fields in rules.items():
         for key, rule in fields.items():
@@ -27,7 +30,8 @@ def calculate_score(input_data, rules):
             if key == "years_in_business" and not value:
                 if "business_start_date" in input_data:
                     value = calculate_years_in_business(
-                        input_data["business_start_date"])
+                        input_data["business_start_date"]
+                    )
 
             if isinstance(value, str):
                 val = value.strip().lower()
@@ -51,5 +55,5 @@ def calculate_score(input_data, rules):
     return {
         "total_score": normalized,
         "raw_score": round(score, 2),
-        "max_possible": max_score
+        "max_possible": max_score,
     }

--- a/templates/form.html
+++ b/templates/form.html
@@ -180,10 +180,18 @@
       // 50 are high risk and do not qualify for offers.
       const risk = score >= 80
         ? '✅ Low Risk'
-        : score >= 50
+        : score >= 60
         ? '⚠️ Moderate Risk'
-        : '❌ High Risk';
-      const color = score >= 80 ? 'success' : score >= 50 ? 'warning' : 'danger';
+        : score >= 50
+        ? '❗ High Risk'
+        : '❌ Super High Risk';
+      const color = score >= 80
+        ? 'success'
+        : score >= 60
+        ? 'warning'
+        : score >= 50
+        ? 'danger'
+        : 'dark';
 
       const output = document.getElementById('scoreOutput');
       output.innerHTML = `
@@ -198,7 +206,7 @@
           </ul>
           <button onclick="downloadPDF()" class="btn btn-outline-primary">Download PDF</button>
         ` : `
-          <div class="alert alert-danger">No offers — high risk of non-repayment.</div>
+          <div class="alert alert-danger">No offers — super high risk of non-repayment.</div>
         `}
       `;
       


### PR DESCRIPTION
## Summary
- don't count second-owner weights unless second owner data is actually provided
- show four risk tiers including Super High Risk
- document the tier thresholds

## Testing
- `black app/utils/scoring.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688bdef1c4ec8328832e4b5ea9ca6609