### PR TITLE
Improve string parsing in score calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ o If Owner 1 < 59%, prompt user to add Owner 2
 o Auto-calculates “Years in Business” from business start date
 2. Scoring Engine
 • Each field has a point weight defined in finance.json
+• Numeric form values may be provided as strings; the scorer will
+  convert them to floats when possible.
 • Total score normalized to a maximum of 100
 • Risk Tier displayed based on score:
   - **Low Risk** (80+)

--- a/app/utils/scoring.py
+++ b/app/utils/scoring.py
@@ -41,6 +41,13 @@ def calculate_score(input_data, rules):
                 elif val in ["no", "false", "bad", "failed"]:
                     score += 0
                     value = None
+                else:
+                    # Attempt to treat the string as a numeric value.  If the
+                    # conversion fails we simply skip scoring for this field.
+                    try:
+                        value = float(value)
+                    except ValueError:
+                        value = None
 
             if value is not None:
                 try:

--- a/tests/test_scoring_strings.py
+++ b/tests/test_scoring_strings.py
@@ -1,0 +1,14 @@
+from app.utils.scoring import calculate_score
+
+
+def test_numeric_fields_as_strings():
+    rules = {
+        "section": {
+            "utilization": {"weight": 10},
+            "inquiries": {"weight": 5},
+        }
+    }
+    input_data = {"utilization": "20", "inquiries": "30"}
+    result = calculate_score(input_data, rules)
+    assert result == {"total_score": 76.67, "raw_score": 11.5, "max_possible": 15}
+


### PR DESCRIPTION
## Summary
- parse numeric strings in `calculate_score`
- add unit test covering numeric-string inputs
- document numeric string handling in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d0d1c08d88328bb45d2440e206f93