### PR TITLE
Fix owner2 detection in scoring

### DIFF
--- a/app/utils/scoring.py
+++ b/app/utils/scoring.py
@@ -15,7 +15,9 @@ def calculate_score(input_data, rules):
     max_score = 0
     owner1_pct = float(input_data.get("owner1_ownership_pct", 100))
     owner2_provided = any(
-        str(v).strip() for k, v in input_data.items() if k.startswith("owner2_")
+        v is not None and str(v).strip() != ""
+        for k, v in input_data.items()
+        if k.startswith("owner2_")
     )
     include_owner2 = owner1_pct < 59 and owner2_provided
 


### PR DESCRIPTION
## Summary
- ensure owner2 fields are considered only when non-empty, preventing `None` or empty strings from triggering owner2 calculations

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890f42913b083288488859d80d8b486