### PR TITLE
Clamp negative numeric values to zero before scoring

### DIFF
--- a/app/utils/scoring.py
+++ b/app/utils/scoring.py
@@ -55,7 +55,7 @@ def calculate_score(input_data, rules):
                     if "utilization" in key or "inquiries" in key:
                         score += max(0, weight - (val / 100) * weight)
                     else:
-                        score += min(val, weight)
+                        score += min(max(val, 0), weight)
                 except (TypeError, ValueError):
                     pass
 


### PR DESCRIPTION
## Summary
- Avoid negative contributions to score by clamping numeric values to zero before limiting by weight

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890f429b8f483288159eab910773749