### PR TITLE
Fix numeric field averages in underwriting assistant

### DIFF
--- a/tests/test_underwriting_assistant.py
+++ b/tests/test_underwriting_assistant.py
@@ -1,0 +1,22 @@
+import json
+
+import underwriting_assistant
+
+
+def test_analyze_logs_numeric_averages(tmp_path, monkeypatch):
+    log_file = tmp_path / "underwriting_data.jsonl"
+    entries = [
+        {"input": {"age": 30}, "score": {"total_score": 1}},
+        {"input": {"age": 40}, "score": {"total_score": 2}},
+        {"input": {"height": 180}, "score": {"total_score": 3}},
+    ]
+    with log_file.open("w") as f:
+        for entry in entries:
+            f.write(json.dumps(entry) + "\n")
+
+    monkeypatch.setattr(underwriting_assistant, "LOG_PATH", log_file)
+
+    report = underwriting_assistant.analyze_logs()
+
+    assert "- age: 35.0" in report
+    assert "- height: 180.0" in report

--- a/underwriting_assistant.py
+++ b/underwriting_assistant.py
@@ -8,7 +8,8 @@ LOG_PATH = Path(__file__).parent / "logs" / "underwriting_data.jsonl"
 def analyze_logs():
     scores = []
     field_frequency = defaultdict(int)
-    field_averages = defaultdict(float)
+    field_totals = defaultdict(float)
+    field_counts = defaultdict(int)
 
     try:
         with open(LOG_PATH, 'r') as f:
@@ -23,7 +24,8 @@ def analyze_logs():
                         
                         for key, val in input_data.items():
                             if isinstance(val, (int, float)):
-                                field_averages[key] += float(val)
+                                field_totals[key] += float(val)
+                                field_counts[key] += 1
                             elif isinstance(val, str) and val.strip():
                                 field_frequency[key] += 1
                     except json.JSONDecodeError:
@@ -44,7 +46,9 @@ def analyze_logs():
         output.append(f"- {field}: {count} times")
 
     output.append("\nAverage Values (Numeric):")
-    for field, total in field_averages.items():
-        output.append(f"- {field}: {round(total/len(scores), 2)}")
+    for field, total in field_totals.items():
+        count = field_counts[field]
+        average = total / count if count else 0
+        output.append(f"- {field}: {round(average, 2)}")
 
     return "\n".join(output)


### PR DESCRIPTION
## Summary
- Track per-field numeric totals and counts in log analysis
- Compute averages using individual field counts
- Test numeric average calculation in underwriting assistant

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68910fab395483289d56c264193f633a