### PR TITLE
Handle invalid business start dates gracefully

### DIFF
--- a/app/utils/scoring.py
+++ b/app/utils/scoring.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import logging
 
 
 def calculate_years_in_business(start_date):
@@ -6,8 +7,11 @@ def calculate_years_in_business(start_date):
         start = datetime.strptime(start_date, "%Y-%m-%d")
         today = datetime.today()
         return round((today - start).days / 365.25, 2)
-    except:
+    except ValueError:
         return 0
+    except Exception:
+        logging.exception("Unexpected error calculating years in business")
+        raise
 
 
 def calculate_score(input_data, rules):


### PR DESCRIPTION
## Summary
- catch `ValueError` when parsing business start dates instead of swallowing all exceptions
- log and re-raise unexpected exceptions for `calculate_years_in_business`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68910fa8b4d88328b47c457b594350ed