### PR TITLE
Trigger second owner fields on ownership below 50%

### DIFF
--- a/templates/form.html
+++ b/templates/form.html
@@ -15,6 +15,7 @@
       const form = document.getElementById('scoreForm');
       let step = 1;
       let owner2Confirmed = false;
+      let owner1PctPrev = 100;
 
       const sectionOrder = [
         "Personal Credit Information",
@@ -97,32 +98,30 @@
           // Conditional Owner 2 fields
           if (isOwner2) wrapper.style.display = 'none';
 
-          if (isOwner1Pct) {
-            /**
-             * Owner 1 ownership percentage controls whether the second owner
-             * section is visible.  The previous implementation listened for
-             * every keystroke (`input`), which could trigger multiple
-             * confirmations or none at all if the field was pre‑filled.  To
-             * provide a more predictable experience, we now listen on
-             * `change`, which fires when the user commits their input (e.g.
-             * leaves the field or presses enter).  Only when the value is
-             * below 59 do we prompt the user about adding a second owner.
-             */
-            input.addEventListener('change', e => {
-              const val = parseFloat(e.target.value);
-              const show = !isNaN(val) && val < 59;
-              // Ask the user once whether they want to add a second owner
-              // when the ownership percentage is below the threshold.  We
-              // only ask again if they later increase the percentage above
-              // the threshold and then reduce it below the threshold again.
-              if (show && !owner2Confirmed) {
-                owner2Confirmed = confirm("Owner 1 owns less than 59%. Do you want to add details for a second owner?");
-              }
-              document.querySelectorAll('[data-owner2="true"]').forEach(el => {
-                el.style.display = (show && owner2Confirmed) ? 'block' : 'none';
+            if (isOwner1Pct) {
+              /**
+               * Owner 1 ownership percentage controls whether the second owner
+               * section is visible. We listen for `input` events so the
+               * interface reacts immediately as the user types. When the value
+               * falls below 50%, the user is asked to confirm adding a second
+               * owner. If the percentage later rises back to 50% or more, the
+               * confirmation resets and the fields are hidden again.
+               */
+              input.addEventListener('input', e => {
+                const val = parseFloat(e.target.value);
+                if (isNaN(val)) return;
+                const below = val < 50;
+                if (below && owner1PctPrev >= 50) {
+                  owner2Confirmed = confirm("Owner 1 owns less than 50%. Do you want to add details for a second owner?");
+                } else if (!below && owner1PctPrev < 50) {
+                  owner2Confirmed = false;
+                }
+                owner1PctPrev = val;
+                document.querySelectorAll('[data-owner2="true"]').forEach(el => {
+                  el.style.display = (below && owner2Confirmed) ? 'block' : 'none';
+                });
               });
-            });
-          }
+            }
 
           wrapper.appendChild(label);
           wrapper.appendChild(input);


### PR DESCRIPTION
## Summary
- react to ownership changes on input and track prior percentage
- show second owner fields when ownership dips below 50% and hide when raised

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890f44c02748328a28087e2eab66b83