### PR TITLE
Handle invalid business start dates in scoring

### DIFF
--- a/app/utils/scoring.py
+++ b/app/utils/scoring.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import logging
 
 
 def calculate_years_in_business(start_date):
@@ -6,8 +7,9 @@ def calculate_years_in_business(start_date):
         start = datetime.strptime(start_date, "%Y-%m-%d")
         today = datetime.today()
         return round((today - start).days / 365.25, 2)
-    except:
-        return 0
+    except ValueError as exc:
+        logging.warning("Malformed business start date: %s", start_date)
+        raise ValueError(f"Malformed business start date: {start_date}") from exc
 
 
 def calculate_score(input_data, rules):

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -1,3 +1,7 @@
+import logging
+
+import pytest
+
 from app.utils.scoring import calculate_score
 
 
@@ -11,4 +15,13 @@ def test_calculate_score_minimal_ruleset():
     input_data = {"num": 7, "bool": "yes"}
     result = calculate_score(input_data, rules)
     assert result == {"total_score": 80.0, "raw_score": 12.0, "max_possible": 15}
+
+
+def test_calculate_score_invalid_business_start_date(caplog):
+    rules = {"section": {"years_in_business": {"weight": 10}}}
+    input_data = {"business_start_date": "not-a-date"}
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(ValueError):
+            calculate_score(input_data, rules)
+    assert "Malformed business start date" in caplog.text
 


### PR DESCRIPTION
## Summary
- log and raise errors on malformed business start dates
- test invalid business start date handling in scoring

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890f4585c488328ad6e24edf2c1d207